### PR TITLE
Add Clang build job and CMake presets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,8 @@ on:
   pull_request:
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04, windows-2022, macos-14]
-        build_type: [Debug, Release]
-
+  linux-gcc:
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Init submodules
@@ -21,16 +16,65 @@ jobs:
         with:
           vcpkgDirectory: "${{ runner.temp }}/vcpkg"
           vcpkgJsonGlob: "vcpkg.json"
-
       - name: Configure
-        run: >
-          cmake -B build
-                -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-                -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
-                -DGH_BUILD_TESTS=ON
-
+        run: cmake --preset linux-gcc
       - name: Build
-        run: cmake --build build --parallel
-
+        run: cmake --build build/linux-gcc --parallel
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build/linux-gcc --output-on-failure
+
+  linux-clang:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Init submodules
+        run: git submodule update --init --recursive
+      - name: Install Clang
+        run: sudo apt-get update && sudo apt-get install -y clang
+      - name: Set up vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: "${{ runner.temp }}/vcpkg"
+          vcpkgJsonGlob: "vcpkg.json"
+      - name: Configure
+        run: cmake --preset linux-clang
+      - name: Build
+        run: cmake --build build/linux-clang --parallel
+      - name: Test
+        run: ctest --test-dir build/linux-clang --output-on-failure
+
+  windows-msvc:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - name: Init submodules
+        run: git submodule update --init --recursive
+      - name: Set up vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: "${{ runner.temp }}/vcpkg"
+          vcpkgJsonGlob: "vcpkg.json"
+      - name: Configure
+        run: cmake --preset windows-msvc
+      - name: Build
+        run: cmake --build build/windows-msvc --parallel --config Release
+      - name: Test
+        run: ctest --test-dir build/windows-msvc --output-on-failure --config Release
+
+  macos:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Init submodules
+        run: git submodule update --init --recursive
+      - name: Set up vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: "${{ runner.temp }}/vcpkg"
+          vcpkgJsonGlob: "vcpkg.json"
+      - name: Configure
+        run: cmake --preset macos
+      - name: Build
+        run: cmake --build build/macos --parallel
+      - name: Test
+        run: ctest --test-dir build/macos --output-on-failure

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,68 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 24
+  },
+  "configurePresets": [
+    {
+      "name": "linux-gcc",
+      "displayName": "Linux GCC",
+      "description": "Build using GCC on Linux",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/linux-gcc",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_TOOLCHAIN_FILE": "${env{VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Release",
+        "GH_BUILD_TESTS": "ON"
+      }
+    },
+    {
+      "name": "linux-clang",
+      "displayName": "Linux Clang",
+      "description": "Build using Clang on Linux",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/linux-clang",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_TOOLCHAIN_FILE": "${env{VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Release",
+        "GH_BUILD_TESTS": "ON"
+      }
+    },
+    {
+      "name": "windows-msvc",
+      "displayName": "Windows MSVC",
+      "description": "Build using MSVC on Windows",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/build/windows-msvc",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${env{VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake",
+        "GH_BUILD_TESTS": "ON"
+      }
+    },
+    {
+      "name": "macos",
+      "displayName": "macOS Clang",
+      "description": "Build using Clang on macOS",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/macos",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_TOOLCHAIN_FILE": "${env{VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Release",
+        "GH_BUILD_TESTS": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "build",
+      "configurePreset": "linux-gcc"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add CMakePresets.json for gcc/clang/msvc toolchains
- update CI workflow to use presets
- add Linux Clang build job and configure Windows job to use Visual Studio
- drop Debug/Release matrix

## Testing
- No tests run since only config files were changed

------
https://chatgpt.com/codex/tasks/task_e_6878e5ace2488323bf5cfe335dca3d91