### PR TITLE
Add Conan package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository contains the `generic_host` C++ library and example projects.
 
 The code in this project is available under the terms of the [MIT License](LICENSE).
 
+## Bootstrapping
+
+Run `./bootstrap.sh` (or `bootstrap.ps1` on Windows) to install required tools and configure the build. The scripts ensure Python and Conan are available, bootstrap vcpkg, and then compile the project.
+
 ## Running the tests
 
 The CMake build does not enable tests by default. To build and run them, configure the project with `GH_BUILD_TESTS` set to `ON`:
@@ -16,3 +20,13 @@ ctest --test-dir build --output-on-failure
 
 The `catch_discover_tests` helper in `CMakeLists.txt` registers each Catch2 test case individually so `ctest` will list them all.
 
+
+## Conan package
+
+A `conanfile.py` is provided to build and package the library. To create a package run:
+
+```bash
+conan create . --output-folder=conan_build
+```
+
+This will build the library and export a Conan package that can be uploaded to your preferred remote.

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -3,6 +3,22 @@ $ErrorActionPreference = "Stop"
 $vcpkgDir = "external/vcpkg"
 $toolchainFile = "$vcpkgDir\scripts\buildsystems\vcpkg.cmake"
 
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    Write-Host ">>> Installing Python..."
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        winget install --id Python.Python.3 -e --source winget
+    }
+    else {
+        Write-Host "Python is required but winget is not available. Please install Python manually." -ForegroundColor Red
+        exit 1
+    }
+}
+
+if (-not (Get-Command conan -ErrorAction SilentlyContinue)) {
+    Write-Host ">>> Installing Conan..."
+    python -m pip install --user conan
+}
+
 Write-Host ">>> Bootstrapping vcpkg..."
 
 # Clone if needed

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -43,6 +43,37 @@ install_packages() {
     esac
 }
 
+install_python() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo ">>> Installing Python..."
+        case "$OS_TYPE" in
+            linux)
+                sudo apt-get update
+                sudo apt-get install -y python3 python3-pip
+                ;;
+            macos)
+                brew install python
+                ;;
+        esac
+    fi
+}
+
+install_conan() {
+    if ! command -v conan >/dev/null 2>&1; then
+        echo ">>> Installing Conan..."
+        case "$OS_TYPE" in
+            linux)
+                sudo apt-get install -y python3-pip
+                python3 -m pip install --user conan
+                ;;
+            macos)
+                brew install python || true
+                python3 -m pip install --user conan
+                ;;
+        esac
+    fi
+}
+
 realpath_f() {
     if command -v realpath >/dev/null 2>&1; then
         realpath "$1"
@@ -56,6 +87,8 @@ EOF
 
 detect_os
 install_packages
+install_python
+install_conan
 
 echo ">>> Bootstrapping vcpkg..."
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,35 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+
+class GenericHostConan(ConanFile):
+    name = "generic_host"
+    version = "0.1.0"
+    license = "MIT"
+    url = "https://github.com/example/cpp_host"
+    description = "Cross-platform .NET-style hosting abstraction for C++"
+    topics = ("host", "cpp")
+
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeToolchain", "CMakeDeps"
+    exports_sources = "CMakeLists.txt", "src/*", "include/*"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires("boost/1.85.0")
+        self.requires("spdlog/1.15.3")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["generic_host"]
+
+


### PR DESCRIPTION
## Summary
- create `conanfile.py` for packaging with Conan
- mention Conan instructions in README
- bootstrap scripts now install Conan automatically
- install Python automatically in bootstrap scripts

## Testing
- `cmake --preset linux-gcc`
- `cmake --build build/linux-gcc`
- `ctest --test-dir build/linux-gcc --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687967c2348c8323b9edf97ff2378394