### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci
 
+permissions:
+  contents: read
+
 on:
   push: { branches: [main] }
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/myarichuk/cpp_host/security/code-scanning/5](https://github.com/myarichuk/cpp_host/security/code-scanning/5)

To address the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the tasks being performed in the workflow (e.g., checking out code, initializing submodules, setting up environments, building, and testing), the required permissions appear to be `contents: read`. This ensures the workflow can read the repository contents but does not grant unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
