### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: release
 
+permissions:
+  contents: read
+  packages: write
+  actions: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/myarichuk/cpp_host/security/code-scanning/1](https://github.com/myarichuk/cpp_host/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file (applies to all jobs) or under the `release` job (specific to that job). Since the workflow requires read access to the repository contents and `write` access for specific actions (e.g., creating releases), the permissions should be restricted to:
- `contents: read` for general repository access.
- `packages: write` and `actions: write` for uploading release artifacts and enabling other workflow functionalities.

The `permissions` block will be added at the root level of the workflow to ensure all jobs inherit these permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
