### PR TITLE
Switch from Boost.DI to Fruit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "external/vcpkg"]
 	path = external/vcpkg
 	url = https://github.com/microsoft/vcpkg.git
-[submodule "external/boost-di"]
-	path = external/boost-di
-	url = https://github.com/boost-experimental/di

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ project(generic_host_cpp VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(BOOST_DI_DIR "${CMAKE_SOURCE_DIR}/external/boost-di/include")
 
 option(GH_BUILD_TESTS "Build Catch2 tests" OFF)
 
@@ -22,11 +21,6 @@ file(GLOB_RECURSE GH_SOURCES CONFIGURE_DEPENDS
 
 add_library(generic_host STATIC ${GH_SOURCES})
 
-target_include_directories(generic_host
-        PUBLIC
-        # consider the folder only at build-time, not install-time
-        $<BUILD_INTERFACE:${BOOST_DI_DIR}>
-)
 
 target_include_directories(generic_host PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -41,12 +35,14 @@ find_package(Boost REQUIRED CONFIG COMPONENTS asio system)
 find_package(spdlog REQUIRED)
 find_package(CLI11 CONFIG REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)
+find_package(fruit CONFIG REQUIRED)
 
 target_link_libraries(generic_host
         PUBLIC
         Boost::asio
         spdlog::spdlog_header_only
         Boost::system
+        fruit::fruit
         PRIVATE
         yaml-cpp::yaml-cpp
         CLI11::CLI11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,20 @@ find_package(Boost REQUIRED CONFIG COMPONENTS asio system)
 find_package(spdlog REQUIRED)
 find_package(CLI11 CONFIG REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)
-find_package(fruit CONFIG REQUIRED)
+find_package(fruit CONFIG)
+if(NOT fruit_FOUND)
+    message(STATUS "fruit package not found via find_package, using manual lookup")
+    find_path(FRUIT_INCLUDE_DIR fruit/fruit.h)
+    find_library(FRUIT_LIBRARY fruit)
+    if(FRUIT_INCLUDE_DIR AND FRUIT_LIBRARY)
+        add_library(fruit::fruit UNKNOWN IMPORTED)
+        set_target_properties(fruit::fruit PROPERTIES
+            IMPORTED_LOCATION "${FRUIT_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${FRUIT_INCLUDE_DIR}")
+    else()
+        message(FATAL_ERROR "fruit library not found")
+    endif()
+endif()
 
 target_link_libraries(generic_host
         PUBLIC

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Run `./bootstrap.sh` (or `bootstrap.ps1` on Windows) to install required tools a
 The CMake build does not enable tests by default. To build and run them, configure the project with `GH_BUILD_TESTS` set to `ON`:
 
 ```bash
-cmake -S . -B build -DGH_BUILD_TESTS=ON
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE=external/vcpkg/scripts/buildsystems/vcpkg.cmake \
+  -DGH_BUILD_TESTS=ON
 cmake --build build
 ctest --test-dir build --output-on-failure
 ```

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -26,15 +26,6 @@ function Install-Conan {
     }
 }
 
-function Ensure-BoostDI {
-    $boostDiPath = "external/boost-di"
-    if (-not (Test-Path $boostDiPath)) {
-        Write-Host ">>> Cloning Boost.DI..."
-        git clone https://github.com/boost-ext/di.git $boostDiPath
-    } else {
-        Write-Host ">>> Boost.DI already exists. Skipping clone."
-    }
-}
 
 if ($Clean) {
     Write-Host ">>> Cleaning build directory..."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -130,14 +130,6 @@ bootstrap_vcpkg() {
   fi
 }
 
-ensure_boost_di() {
-  if [[ ! -d "external/boost-di" ]]; then
-    log "Cloning Boost.DI..."
-    git clone https://github.com/boost-ext/di.git external/boost-di
-  else
-    log "Boost.DI already exists. Skipping clone."
-  fi
-}
 
 install_packages() {
   local PKGS=()

--- a/include/generic_host/HostBuilder.hpp
+++ b/include/generic_host/HostBuilder.hpp
@@ -5,6 +5,7 @@
 #include "ConsoleLifecycle.h"
 #include "HostImpl.hpp"
 #include "IHostLifecycle.h"
+#include "ServiceCollection.hpp"
 
 namespace gh {
     class Host;
@@ -71,5 +72,5 @@ namespace gh {
         }
     };
 
-    using DefaultHostBuilder = HostBuilder<int>;
+    using DefaultHostBuilder = HostBuilder<ServiceCollection>;
 }

--- a/include/generic_host/HostImpl.hpp
+++ b/include/generic_host/HostImpl.hpp
@@ -2,6 +2,8 @@
 #include <boost/asio/signal_set.hpp>
 #include "IHostedService.hpp"
 #include "IHostLifecycle.h"
+#include "ServiceCollection.hpp"
+#include <fruit/fruit.h>
 #include <spdlog/logger.h>
 #include <spdlog/sinks/null_sink.h>
 
@@ -13,28 +15,17 @@ namespace gh {
         }
     }
 
-    /*
-    template<class F>
-    auto configureServices(F&& f) {
-        auto services = Services{}.AddSingleton(detail::create_null_logger());  // using Services = ServiceCollection<>
-        f(services);                 // mutates it
-        return services;            // return the modified collection
-    }
-*/
 
     template<class ServiceList>
     class HostImpl {
         ServiceList services_;
         std::shared_ptr<IHostLifecycle> lifecycle_;
         std::shared_ptr<boost::asio::io_context> io_;
-/*
-        [[nodiscard]] auto buildDI() const
-        {
-            return std::apply(
-                [](auto&&... f){ return di::make_injector(f()...); },
-                services_.binds);
+
+        [[nodiscard]] auto buildInjector() const {
+            auto comp = services_.buildComponent();
+            return fruit::Injector<>(comp);
         }
-        */
 
     public:
         explicit HostImpl(
@@ -47,26 +38,22 @@ namespace gh {
             lifecycle_->Shutdown();
         }
 
-        [[nodiscard]] int Run() const
-        {
-            /*
-            auto di = buildDI();
-
-            // resolve all registered IHostedService's
-            auto services = di.template create<std::vector<std::shared_ptr<IHostedService>>>();
+        [[nodiscard]] int Run() const {
+            auto injector = buildInjector();
+            auto services = injector.getMultibindings<IHostedService*>();
 
             lifecycle_->Start();
 
-            for(const auto serviceInstance : services){
+            for (auto serviceInstance : services) {
                 serviceInstance->Start(*io_);
             }
 
             lifecycle_->WaitForShutdownAsync().wait();
 
-            for(const auto serviceInstance : services){
+            for (auto serviceInstance : services) {
                 serviceInstance->Stop();
             }
-*/
+
             return 0;
         }
     };

--- a/include/generic_host/ServiceCollection.hpp
+++ b/include/generic_host/ServiceCollection.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include <fruit/fruit.h>
+#include <functional>
+#include <memory>
+#include <vector>
+#include <spdlog/logger.h>
+#include "IHostedService.hpp"
+
+namespace gh {
+    class ServiceCollection {
+        std::vector<std::function<fruit::Component<>()>> registrations_{};
+    public:
+        ServiceCollection() = default;
+
+        ServiceCollection(std::vector<std::function<fruit::Component<>()>> regs)
+            : registrations_(std::move(regs)) {}
+
+        ServiceCollection AddSingletonInstance(std::shared_ptr<spdlog::logger> logger) const {
+            auto regs = registrations_;
+            regs.push_back([logger]() {
+                return fruit::createComponent()
+                    .bindInstance<std::shared_ptr<spdlog::logger>>(logger);
+            });
+            return ServiceCollection{std::move(regs)};
+        }
+
+        template <class T>
+        ServiceCollection AddHostedService() const {
+            auto regs = registrations_;
+            regs.push_back([]() {
+                return fruit::createComponent()
+                    .addMultibinding<IHostedService, T>();
+            });
+            return ServiceCollection{std::move(regs)};
+        }
+
+        fruit::Component<> buildComponent() const {
+            auto comp = fruit::createComponent();
+            for (const auto& r : registrations_) {
+                comp = comp.install(r());
+            }
+            return comp;
+        }
+    };
+}

--- a/tests/ServiceHostingTests.cpp
+++ b/tests/ServiceHostingTests.cpp
@@ -3,7 +3,6 @@
 #include <spdlog/logger.h>
 #include <spdlog/sinks/ringbuffer_sink.h>
 #include <boost/asio/steady_timer.hpp>
-/*
 using namespace gh;
 
 class FooService final : public IHostedService {
@@ -163,4 +162,3 @@ TEST_CASE("Should run multiple async services concurrently") {
     REQUIRE(heartbeatCount >= 5);
     REQUIRE(pingCount >= 3);
 }
-*/

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,7 @@
     "boost-stacktrace",
     "yaml-cpp",
     "cli11",
+    "fruit",
     "spdlog",
     "catch2"
   ],


### PR DESCRIPTION
## Summary
- drop Boost.DI submodule
- add Fruit dependency
- implement a simple Fruit-based ServiceCollection
- wire fruit into HostImpl
- enable service hosting tests

## Testing
- `cmake -S . -B build -DGH_BUILD_TESTS=ON` *(fails: Could not find a package configuration file provided by "fruit" ...)*

------
https://chatgpt.com/codex/tasks/task_e_6885421240548323bb41333a303697a2